### PR TITLE
chore(github): tweak return type of `globs_to_assets`

### DIFF
--- a/src/builtin_plugins/github.rs
+++ b/src/builtin_plugins/github.rs
@@ -185,7 +185,7 @@ impl PluginInterface for GithubPlugin {
 
         let mut errored = false;
 
-        let (assets, errors) = globs_to_assets(cfg.assets.as_value().iter().map(String::as_str));
+        let (assets, mut errors) = globs_to_assets(cfg.assets.as_value().iter().map(String::as_str));
         if !errors.is_empty() {
             return PluginResponse::from_error(errors.swap_remove(0));
         }


### PR DESCRIPTION
This helps to avoid `.into_iter().map(...).collect()` chain.

Ideally `globs_to_assets` should return just `Result<Vec<Asset>, Error>`, but this would require changing the behaivior of existing code.