### PR TITLE
feat(core): CLI option for setting the workdir path

### DIFF
--- a/cleanroom/src/test_runner/mod.rs
+++ b/cleanroom/src/test_runner/mod.rs
@@ -84,8 +84,9 @@ impl TestRunner<Prepared<'_>> {
 
         // Run semanteecore
         log::info!("testing {}::{}::{}", info.domain, info.test, info.subtest);
+
         let status = Command::new(semanteecore_path)
-            .current_dir(workdir.path())
+            .args(&["--path", workdir.path().to_str().unwrap()])
             .status()
             .context("failed to run semanteecore")?;
 

--- a/src/builtin_plugins/git.rs
+++ b/src/builtin_plugins/git.rs
@@ -238,7 +238,7 @@ impl State {
                 let should_ignore = self
                     .repo
                     .status_should_ignore(path)
-                    // TODO Is is correct to ignoring files if git-ignore check failed?
+                    // TODO Is is correct to ignore files if git-ignore check has failed?
                     .unwrap_or(true);
 
                 if should_ignore {

--- a/src/builtin_plugins/git.rs
+++ b/src/builtin_plugins/git.rs
@@ -216,7 +216,7 @@ impl State {
 
                 log::trace!("file path = {}", file_path.display());
 
-                let git_path = file_path
+                file_path
                     .strip_prefix(&repo_path)
                     .map_err(|e| {
                         log::warn!(
@@ -226,13 +226,9 @@ impl State {
                         )
                     })
                     .map(ToOwned::to_owned)
-                    .ok();
-
-                git_path.map(|p| {
-                    log::trace!("git file path = {}", p.display());
-                    p
-                })
+                    .ok()
             })
+            .inspect(|p| log::trace!("git file path = {}", p.display()))
             // Then -- filter out gitignored files
             .filter(|path| {
                 let should_ignore = self

--- a/src/builtin_plugins/git.rs
+++ b/src/builtin_plugins/git.rs
@@ -186,13 +186,71 @@ impl State {
     }
 
     fn commit_files(&self, config: &Config, files: &[String], commit_msg: &str) -> Result<(), failure::Error> {
-        let files = files.iter().filter(|filename| {
-            let path = Path::new(filename);
-            !self
-                .repo
-                .status_should_ignore(path)
-                .expect("Determining ignore status of file failed")
-        });
+        let _span = crate::logger::span("commit");
+
+        let repo_path = self
+            .repo
+            .path()
+            .parent()
+            .ok_or(failure::err_msg("cannot find repository path"))?
+            .canonicalize()?;
+
+        log::trace!("converting project paths to git repo paths");
+        log::trace!("project path = {}", repo_path.display());
+
+        let files = files
+            .iter()
+            // First -- convert paths relative to project root to paths relative to git repository
+            .filter_map(|path| {
+                let file_path = Path::new(path);
+                let file_path = file_path
+                    .canonicalize()
+                    .map_err(|e| {
+                        log::warn!(
+                            "failed to canonicalize file path {}, skipping it: {}",
+                            file_path.display(),
+                            e
+                        )
+                    })
+                    .ok()?;
+
+                log::trace!("file path = {}", file_path.display());
+
+                let git_path = file_path
+                    .strip_prefix(&repo_path)
+                    .map_err(|e| {
+                        log::warn!(
+                            "failed to convert {} to relative git path, skipping it: {}",
+                            file_path.display(),
+                            e
+                        )
+                    })
+                    .map(ToOwned::to_owned)
+                    .ok();
+
+                git_path.map(|p| {
+                    log::trace!("git file path = {}", p.display());
+                    p
+                })
+            })
+            // Then -- filter out gitignored files
+            .filter(|path| {
+                let should_ignore = self
+                    .repo
+                    .status_should_ignore(path)
+                    // TODO Is is correct to ignoring files if git-ignore check failed?
+                    .unwrap_or(true);
+
+                if should_ignore {
+                    log::warn!(
+                        "failed to check if {} should be gitignored => ignoring the file",
+                        path.display()
+                    );
+                }
+
+                !should_ignore
+            })
+            .inspect(|p| log::info!("Adding file {}", p.display()));
 
         self.add(files)?;
 
@@ -384,7 +442,7 @@ impl PluginInterface for GitPlugin {
 
         let mut data = {
             let path = config.project_root.as_value();
-            let repo = Repository::open(path)?;
+            let repo = Repository::discover(path)?;
             State::new(config, repo)?
         };
 
@@ -431,7 +489,6 @@ impl PluginInterface for GitPlugin {
         let commit_msg = format!("chore(release): Version {} [skip ci]", next_version);
         let tag_name = format!("v{}", next_version);
 
-        log::info!("Committing files {:?}", files_to_commit);
         state.commit_files(config, &files_to_commit, &commit_msg)?;
         log::info!("Creating tag {:?}", tag_name);
         state.create_tag(config, &tag_name, &changelog)?;

--- a/src/builtin_plugins/rust.rs
+++ b/src/builtin_plugins/rust.rs
@@ -83,12 +83,19 @@ impl PluginInterface for RustPlugin {
     fn get_value(&self, key: &str) -> response::GetValue {
         let value = match key {
             "files_to_commit" => {
-                let mut files_to_commit = vec!["Cargo.toml"];
+                let mut files_to_commit = Vec::with_capacity(2);
+
                 let project_root = self.config.project_root.as_value();
                 let project_root: &Path = project_root.as_ref();
-                if project_root.join("Cargo.lock").exists() {
-                    files_to_commit.push("Cargo.lock");
+
+                let cargo_toml = project_root.join("Cargo.toml");
+                files_to_commit.push(cargo_toml);
+
+                let cargo_lock = project_root.join("Cargo.lock");
+                if cargo_lock.exists() {
+                    files_to_commit.push(cargo_lock);
                 }
+
                 serde_json::to_value(files_to_commit)?
             }
             _other => return PluginResponse::from_error(FlowError::KeyNotSupported(key.to_owned()).into()),

--- a/src/builtin_plugins/rust.rs
+++ b/src/builtin_plugins/rust.rs
@@ -1,3 +1,4 @@
+use std::array;
 use std::fs::File;
 use std::io::{Read, Write};
 use std::ops::Try;
@@ -11,6 +12,7 @@ use crate::plugin_support::flow::{FlowError, ProvisionCapability, Value};
 use crate::plugin_support::keys::{DRY_RUN, FILES_TO_COMMIT, NEXT_VERSION, PROJECT_ROOT};
 use crate::plugin_support::proto::response::{self, PluginResponse};
 use crate::plugin_support::{PluginInterface, PluginStep};
+use crate::utils::SerIter;
 
 pub struct RustPlugin {
     dry_run_guard: Option<DryRunGuard>,
@@ -83,20 +85,15 @@ impl PluginInterface for RustPlugin {
     fn get_value(&self, key: &str) -> response::GetValue {
         let value = match key {
             "files_to_commit" => {
-                let mut files_to_commit = Vec::with_capacity(2);
-
                 let project_root = self.config.project_root.as_value();
                 let project_root: &Path = project_root.as_ref();
 
                 let cargo_toml = project_root.join("Cargo.toml");
-                files_to_commit.push(cargo_toml);
-
                 let cargo_lock = project_root.join("Cargo.lock");
-                if cargo_lock.exists() {
-                    files_to_commit.push(cargo_lock);
-                }
 
-                serde_json::to_value(files_to_commit)?
+                let files_to_commit = array::IntoIter::new([cargo_toml, cargo_lock]).filter(|p| p.exists());
+
+                serde_json::to_value(SerIter::from(files_to_commit))?
             }
             _other => return PluginResponse::from_error(FlowError::KeyNotSupported(key.to_owned()).into()),
         };

--- a/src/config.rs
+++ b/src/config.rs
@@ -32,27 +32,14 @@ pub struct Config {
     pub cfg: ValueDefinitionMap,
 }
 
-fn default_project_root() -> ValueDefinition {
-    let root = PathBuf::from("./");
-    let root = root.canonicalize().ok();
-    let root = root.and_then(|p| p.to_str().map(String::from));
-
-    if let Some(path) = root {
-        ValueDefinition::Value(serde_json::Value::String(path))
-    } else {
-        panic!(
-            "failed to derive project_root from environment, please set cfg.project_root manually in releaserc.toml"
-        );
-    }
-}
-
 fn default_dry_run() -> ValueDefinition {
     ValueDefinition::Value(serde_json::Value::Bool(false))
 }
 
 impl Config {
     pub fn from_toml<P: AsRef<Path>>(path: P, is_dry_run: bool) -> Result<Self, failure::Error> {
-        let mut file = File::open(path).map_err(|err| match err.kind() {
+        let config_path = path.as_ref();
+        let mut file = File::open(config_path).map_err(|err| match err.kind() {
             std::io::ErrorKind::NotFound => ConfigError::FileNotFound.into(),
             _other => failure::Error::from(err),
         })?;
@@ -72,10 +59,14 @@ impl Config {
             }
         });
 
-        config
-            .cfg
-            .entry("project_root".into())
-            .or_insert_with(default_project_root);
+        let workspace_path = config_path.parent().ok_or_else(|| {
+            failure::format_err!(
+                "couldn't find workspace directory; try using an absolute path to config with --path option"
+            )
+        })?;
+        let workspace_path_value = ValueDefinition::Value(serde_json::to_value(workspace_path.to_owned())?);
+
+        config.cfg.entry("project_root".into()).or_insert(workspace_path_value);
 
         Ok(config)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![feature(try_trait, external_doc)]
+#![feature(try_trait, external_doc, array_value_iter)]
 #![doc(include = "../README.md")]
 
 #[macro_use]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,7 @@ use crate::plugin_runtime::kernel::InjectionTarget;
 use crate::plugin_support::PluginStep;
 use plugin_runtime::Kernel;
 
+use std::path::PathBuf;
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]
@@ -33,6 +34,9 @@ pub struct Args {
     /// Silent mode: no logs
     #[structopt(short, long)]
     pub silent: bool,
+    /// Path to project root directory
+    #[structopt(short, long, parse(from_os_str), default_value = "./")]
+    pub path: PathBuf,
 }
 
 pub fn run(args: Args) -> Result<(), failure::Error> {
@@ -45,7 +49,7 @@ pub fn run(args: Args) -> Result<(), failure::Error> {
 
     log::info!("semanteecore 🚀");
 
-    let config = Config::from_toml("./releaserc.toml", args.dry)?;
+    let config = Config::from_toml(args.path.join("releaserc.toml"), args.dry)?;
 
     let kernel = Kernel::builder(config)
         .inject_plugin(

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,4 +1,6 @@
 use failure::SyncFailure;
+use serde::{Serialize, Serializer};
+use std::cell::RefCell;
 
 pub trait ResultExt<T, E> {
     fn sync(self) -> Result<T, SyncFailure<E>>
@@ -14,5 +16,36 @@ impl<T, E> ResultExt<T, E> for Result<T, E> {
         E: ::std::error::Error + Send + 'static,
     {
         self.map_err(SyncFailure::new)
+    }
+}
+
+// This serde helper struct allows to avoid collecting iterator into serde_json::Value,
+// through consuming iterator in the serialization process directly
+pub struct SerIter<I>(RefCell<I>);
+
+impl<I> From<I> for SerIter<I> {
+    fn from(iter: I) -> Self {
+        SerIter(RefCell::new(iter))
+    }
+}
+
+// Clippy fires false-positive
+#[allow(clippy::while_let_on_iterator)]
+impl<I, T> Serialize for SerIter<I>
+where
+    T: Serialize,
+    I: Iterator<Item = T>,
+{
+    fn serialize<S>(&self, s: S) -> Result<<S as Serializer>::Ok, <S as Serializer>::Error>
+    where
+        S: Serializer,
+    {
+        use serde::ser::SerializeSeq;
+        let mut seq = s.serialize_seq(None)?;
+        let mut iter = self.0.borrow_mut();
+        while let Some(item) = iter.next() {
+            seq.serialize_element(&item)?;
+        }
+        seq.end()
     }
 }


### PR DESCRIPTION
Now semanteecore can be called with option `--path`,
which specifies the project root directory (`./` by default)

_____________________________________________

Depends on #39
Closes #35